### PR TITLE
Fix fileNameWithoutHashed only keeping first word in the name.

### DIFF
--- a/src/Commands/GenerateWebPackAssetCommand.php
+++ b/src/Commands/GenerateWebPackAssetCommand.php
@@ -121,7 +121,8 @@ class GenerateWebPackAssetCommand extends BaseCommand
         }
 
         $explodedFileName = explode($extensionSplit, $filename);
-        return $explodedFileName[0];
+        array_pop($explodedFileName);
+        return implode($extensionSplit, $explodedFileName);
     }
 
 }


### PR DESCRIPTION
https://grin.atlassian.net/browse/GN-24155
Fix webpack-assets.json file truncated key, resulting in failed landing page & fashion nova on Live.
Before:
```
"fashion":{
    "js":"\/fashion-nova-adde564a7749595a2bf0.js"
 },
 "fashion-nova-adde564a7749595a2bf0.js.LICENSE":{
    "txt":"\/fashion-nova-adde564a7749595a2bf0.js.LICENSE.txt"
 },
 "fashion-nova":{
    "css":"\/fashion-nova.9ea469c3a1bc0add7b91.css"
 },
"landing":{
    "js":"\/landing-page-adde564a7749595a2bf0.js"
 },
 "landing-page-adde564a7749595a2bf0.js.LICENSE":{
    "txt":"\/landing-page-adde564a7749595a2bf0.js.LICENSE.txt"
 },
 "landing-page":{
    "css":"\/landing-page.49cb395e2f9cbe5b4804.css"
 },
```
After:
```
    "fashion-nova": {
        "js": "/fashion-nova-adde564a7749595a2bf0.js",
        "css": "/fashion-nova.9ea469c3a1bc0add7b91.css"
    },
    "landing-page": {
        "js": "/landing-page-adde564a7749595a2bf0.js",
        "css": "/landing-page.49cb395e2f9cbe5b4804.css"
    },
```